### PR TITLE
Add missing features

### DIFF
--- a/pacs/efm32tg/Cargo.toml
+++ b/pacs/efm32tg/Cargo.toml
@@ -33,6 +33,7 @@ efm32tg842 = []
 [dependencies.portable-atomic]
 version = "~1"
 default-features = false
+features = ["critical-section"]
 
 [dependencies.critical-section]
 version = "~1"

--- a/pacs/efm32tg11b/Cargo.toml
+++ b/pacs/efm32tg11b/Cargo.toml
@@ -24,11 +24,11 @@ efm32tg11b320 = []
 efm32tg11b340 = []
 efm32tg11b520 = []
 efm32tg11b540 = []
+critical-section = ["portable-atomic/critical-section", "dep:critical-section"]
 
 [dependencies.portable-atomic]
 version = "~1"
 default-features = false
-features = ["critical-section"]
 
 [dependencies.critical-section]
 version = "~1"

--- a/pacs/efm32tg11b/Cargo.toml
+++ b/pacs/efm32tg11b/Cargo.toml
@@ -28,6 +28,7 @@ efm32tg11b540 = []
 [dependencies.portable-atomic]
 version = "~1"
 default-features = false
+features = ["critical-section"]
 
 [dependencies.critical-section]
 version = "~1"


### PR DESCRIPTION
Using the latest PAC I found several compiler errors:
```
error[E0599]: no method named `or` found for struct `portable_atomic::AtomicU8` in the current scope
--> /home/nathan/.cargo/registry/src/github.com-1ecc6299db9ec823/efm32tg11b-pac-0.1.3/src/generic.rs:705:48
|
705 |                     (*(ptr as *const $Atomic)).or(val, Ordering::SeqCst);
|                                                ^^ method not found in `portable_atomic::AtomicU8`
...
719 |     impl_atomics!(u8, portable_atomic::AtomicU8);
|     -------------------------------------------- in this macro invocation
|
= note: this error originates in the macro `impl_atomics` (in Nightly builds, run with -Z macro-backtrace for more info)
```
Adding the "critical-section" feature fixes the issue.